### PR TITLE
Add option to keep decimals for parenthesis notation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: errors
 Type: Package
 Title: Uncertainty Propagation for R Vectors
-Version: 0.4.2
+Version: 0.4.2.1
 Authors@R: c(
     person("Iñaki", "Ucar", email="iucar@fedoraproject.org",
       role=c("aut", "cph", "cre"), comment=c(ORCID="0000-0001-6403-5550")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# errors 0.4.3
+
+- add option to print uncertainty with decimal point when appropriate
+  in the `parenthesis` notation
+
 # errors 0.4.2
 
 - Add support for PDG rounding rules (@davidchall #59 addressing #45).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
-# errors 0.4.3
+# errors devel
 
-- add option to print uncertainty with decimal point when appropriate
-  in the `parenthesis` notation
+- Add option `decimals` to `format()` method to add support for uncertainty with
+  decimals in the `parenthesis` notation (@alusiani #60 addressing #47).
 
 # errors 0.4.2
 

--- a/R/print.R
+++ b/R/print.R
@@ -37,22 +37,22 @@ format.errors = function(x,
                          ...)
 {
   stopifnot(notation %in% c("parenthesis", "plus-minus"))
+
   if (is.null(digits))
     digits <- getOption("errors.digits", 1)
   digits <- if (digits == "pdg") digits_pdg(.e(x)) else rep(digits, length(x))
+
   scipen <- getOption("scipen", 0)
   prepend <- rep("", length(x))
   append <- rep("", length(x))
 
   e <- signif(.e(x), digits)
   nulle <- e == 0 & !is.na(e)
-  e_expon = get_exponent(e)
-  xexp <- ifelse(.v(x)==0, e_expon+1, get_exponent(x))
-  value_digits <- ifelse(e, digits - e_expon, digits)
+  eexp <- get_exponent(e)
+  xexp <- ifelse(.v(x)== 0, eexp+1, get_exponent(x))
+  value_digits <- ifelse(e, digits - eexp, digits)
   value <- ifelse(e, signif(.v(x), xexp + value_digits), .v(x))
-  ##+++ str(value)
   value <- ifelse(is.finite(value), value, .v(x))
-  ##+++ str(value)
 
   cond <- (scientific | (xexp > 4+scipen | xexp < -3-scipen)) & is.finite(e)
   e[cond] <- e[cond] * 10^(-xexp[cond])
@@ -69,7 +69,7 @@ format.errors = function(x,
       e[is.finite(e)] <- (e * 10^(pmax(0, value_digits-1)))[is.finite(e)]
     } else {
       ## convert uncertainty for printing, keeping decimal point in line with value
-      e_scale_flag = (cond & e_expon < xexp) | (!cond & is.finite(e) & e_expon<0)
+      e_scale_flag = (cond & eexp < xexp) | (!cond & is.finite(e) & eexp<0)
       e[e_scale_flag] <- (e * 10^(pmax(0, value_digits-1)))[e_scale_flag]
     }
   } else {
@@ -92,6 +92,7 @@ format.errors = function(x,
             decimal.mark=getOption("OutDec"))
   })
   e <- sub("\\.$", "", e)
+
   paste(prepend, value, sep, e, append, sep="")
 }
 

--- a/man/format.errors.Rd
+++ b/man/format.errors.Rd
@@ -19,7 +19,10 @@ value according to the Particle Data Group rounding rule (see references).}
 encoded in scientific format.}
 
 \item{notation}{error notation; \code{"parenthesis"} and \code{"plus-minus"}
-are supported through the \code{"errors.notation"} option.}
+are supported through the \code{"errors.notation"} option.
+When using the "parenthesis" error notation, by default the uncertainty
+is formatted without any decimal point, unless the option
+\code{"errors.parenthesis.unc.dec.point"} is set to TRUE.}
 
 \item{...}{ignored.}
 }

--- a/man/format.errors.Rd
+++ b/man/format.errors.Rd
@@ -4,14 +4,14 @@
 \alias{format.errors}
 \title{Encode \code{errors}}
 \usage{
-\method{format}{errors}(x, digits = NULL, scientific = FALSE,
-  notation = getOption("errors.notation", "parenthesis"), ...)
+\method{format}{errors}(x, digits = getOption("errors.digits", 1),
+  scientific = FALSE, notation = getOption("errors.notation",
+  "parenthesis"), decimals = getOption("errors.decimals", FALSE), ...)
 }
 \arguments{
 \item{x}{an \code{errors} object.}
 
 \item{digits}{how many significant digits are to be used for uncertainties.
-The default, \code{NULL}, uses \code{getOption("errors.digits", 1)}.
 Use \code{digits="pdg"} to choose an appropriate number of digits for each
 value according to the Particle Data Group rounding rule (see references).}
 
@@ -19,10 +19,12 @@ value according to the Particle Data Group rounding rule (see references).}
 encoded in scientific format.}
 
 \item{notation}{error notation; \code{"parenthesis"} and \code{"plus-minus"}
-are supported through the \code{"errors.notation"} option.
-When using the "parenthesis" error notation, by default the uncertainty
-is formatted without any decimal point, unless the option
-\code{"errors.parenthesis.unc.dec.point"} is set to TRUE.}
+are supported through the \code{"errors.notation"} option.}
+
+\item{decimals}{logical specifying whether the uncertainty should be formatted
+with a decimal point even when the \code{"parenthesis"} notation is used.
+Otherwise (by default), the \code{"parenthesis"} notation scales the
+uncertainty to match the least significant digit of the value.}
 
 \item{...}{ignored.}
 }
@@ -33,6 +35,7 @@ Format an \code{errors} object for pretty printing.
 x <- set_errors(1:3*100, 1:3*100 * 0.05)
 format(x)
 format(x, digits=2)
+format(x, digits=2, decimals=TRUE)
 format(x, scientific=TRUE)
 format(x, notation="plus-minus")
 

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -23,6 +23,9 @@ test_that("error formatting works properly", {
   expect_equal(format(x, notation="parenthesis", scientific=TRUE),
                c("1(1000)e4", "1.1(1)e4", "1.111(1)e4", "1.1111(1)e4", "1.11112(1)e4",
                  "1.111122(1)e4", "1.111122222(1)e4", "1.111122222000(1)e4"))
+  expect_equal(format(x, notation="parenthesis", digits=3, decimals=TRUE),
+               c("10000(12300000)", "11110(1230)", "11111.2(12.3)", "11111.22(1.23)",
+                 "11111.222(123)", "11111.2222(123)", "11111.2222200(123)", "11111.2222200000(123)"))
 
   expect_equal(format(x, notation="plus-minus"), sapply(list(
     c("10000", "10000000"), c("11000", "1000"), c("11110", "10"), c("11111", "1"),
@@ -41,14 +44,6 @@ test_that("error formatting works properly", {
     c("(1.11112", "0.00001)e4"), c("(1.111122", "0.000001)e4"), c("(1.111122222", "0.000000001)e4"),
     c("(1.111122222000", "0.000000000001)e4")),
     paste, collapse=paste("", .pm, "")))
-  #
-  # test using option to keep decimal point in uncertainty in parenthesis notation
-  #
-  saved_options = options(errors.parenthesis.unc.dec.point = TRUE)
-  expect_equal(format(x, notation="parenthesis", digits=3),
-               c("10000(12300000)", "11110(1230)", "11111.2(12.3)", "11111.22(1.23)",
-                 "11111.222(123)", "11111.2222(123)", "11111.2222200(123)", "11111.2222200000(123)"))
-  options(saved_options)
 
   x <- set_errors(rep(0.827, 3), c(0.119, 0.367, 0.962))
   expect_equal(format(x, notation="plus-minus", digits="pdg"), sapply(list(

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -17,9 +17,6 @@ test_that("error formatting works properly", {
   expect_equal(format(x, notation="parenthesis", digits=3),
                c("10000(12300000)", "11110(1230)", "11111.2(123)", "11111.22(123)",
                  "11111.222(123)", "11111.2222(123)", "11111.2222200(123)", "11111.2222200000(123)"))
-  expect_equal(format(x, notation="parenthesis", digits="pdg"),
-               c("10000(12000000)", "11100(1200)", "11111(12)", "11111.2(12)",
-                 "11111.22(12)", "11111.222(12)", "11111.222220(12)", "11111.222220000(12)"))
   expect_equal(format(x, notation="parenthesis", scientific=TRUE),
                c("1(1000)e4", "1.1(1)e4", "1.111(1)e4", "1.1111(1)e4", "1.11112(1)e4",
                  "1.111122(1)e4", "1.111122222(1)e4", "1.111122222000(1)e4"))
@@ -32,33 +29,27 @@ test_that("error formatting works properly", {
     c("10000", "12300000"), c("11110", "1230"), c("11111.2", "12.3"), c("11111.22", "1.23"),
     c("11111.222", "0.123"), c("11111.2222", "0.0123"), c("11111.2222200", "0.0000123"), c("11111.2222200000", "0.0000000123")),
     paste, collapse=paste("", .pm, "")))
-  expect_equal(format(x, notation="plus-minus", digits="pdg"), sapply(list(
-    c("10000", "12000000"), c("11100", "1200"), c("11111", "12"), c("11111.2", "1.2"),
-    c("11111.22", "0.12"), c("11111.222", "0.012"), c("11111.222220", "0.000012"), c("11111.222220000", "0.000000012")),
-    paste, collapse=paste("", .pm, "")))
   expect_equal(format(x, notation="plus-minus", scientific=TRUE), sapply(list(
     c("(1", "1000)e4"), c("(1.1", "0.1)e4"), c("(1.111", "0.001)e4"), c("(1.1111", "0.0001)e4"),
     c("(1.11112", "0.00001)e4"), c("(1.111122", "0.000001)e4"), c("(1.111122222", "0.000000001)e4"),
     c("(1.111122222000", "0.000000000001)e4")),
     paste, collapse=paste("", .pm, "")))
-
-  x <- set_errors(rep(0.827, 3), c(0.119, 0.367, 0.962))
-  expect_equal(format(x, notation="plus-minus", digits="pdg"), sapply(list(
-    c("0.83", "0.12"), c("0.8", "0.4"), c("1", "1")),
-    paste, collapse=paste("", .pm, "")))
+  #
+  # test using option to keep decimal point in uncertainty in parenthesis notation
+  #
+  saved_options = options(errors.parenthesis.unc.dec.point = TRUE)
+  expect_equal(format(x, notation="parenthesis", digits=3),
+               c("10000(12300000)", "11110(1230)", "11111.2(12.3)", "11111.22(1.23)",
+                 "11111.222(123)", "11111.2222(123)", "11111.2222200(123)", "11111.2222200000(123)"))
+  options(saved_options)
 
   x <- set_errors(10, 1)
   expect_equal(format(x - set_errors(10)), "0(1)")
   expect_equal(format(x - x), "0(0)")
 
-  x <- set_errors(c(0.4, NA, NaN, Inf, -Inf))
+  x <- set_errors(c(0.4, NA, NaN, Inf))
   expect_equal(format(x[1]), "0.4(0)")
   expect_equal(format(x[2]), "NA(NA)")
   expect_equal(format(x[3]), "NaN(NaN)")
   expect_equal(format(x[4]), "Inf(Inf)")
-  expect_equal(format(x[5]), "-Inf(Inf)")
-
-  x <- set_errors(c(0e10, 1e12), 0.1e12)
-  expect_equal(format(x), c("0.0(1)e12", "1.0(1)e12"))
-  expect_equal(format(x, digits=2), c("0.00(10)e12", "1.00(10)e12"))
 })

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -17,6 +17,9 @@ test_that("error formatting works properly", {
   expect_equal(format(x, notation="parenthesis", digits=3),
                c("10000(12300000)", "11110(1230)", "11111.2(123)", "11111.22(123)",
                  "11111.222(123)", "11111.2222(123)", "11111.2222200(123)", "11111.2222200000(123)"))
+  expect_equal(format(x, notation="parenthesis", digits="pdg"),
+               c("10000(12000000)", "11100(1200)", "11111(12)", "11111.2(12)",
+                 "11111.22(12)", "11111.222(12)", "11111.222220(12)", "11111.222220000(12)"))
   expect_equal(format(x, notation="parenthesis", scientific=TRUE),
                c("1(1000)e4", "1.1(1)e4", "1.111(1)e4", "1.1111(1)e4", "1.11112(1)e4",
                  "1.111122(1)e4", "1.111122222(1)e4", "1.111122222000(1)e4"))
@@ -28,6 +31,10 @@ test_that("error formatting works properly", {
   expect_equal(format(x, notation="plus-minus", digits=3), sapply(list(
     c("10000", "12300000"), c("11110", "1230"), c("11111.2", "12.3"), c("11111.22", "1.23"),
     c("11111.222", "0.123"), c("11111.2222", "0.0123"), c("11111.2222200", "0.0000123"), c("11111.2222200000", "0.0000000123")),
+    paste, collapse=paste("", .pm, "")))
+  expect_equal(format(x, notation="plus-minus", digits="pdg"), sapply(list(
+    c("10000", "12000000"), c("11100", "1200"), c("11111", "12"), c("11111.2", "1.2"),
+    c("11111.22", "0.12"), c("11111.222", "0.012"), c("11111.222220", "0.000012"), c("11111.222220000", "0.000000012")),
     paste, collapse=paste("", .pm, "")))
   expect_equal(format(x, notation="plus-minus", scientific=TRUE), sapply(list(
     c("(1", "1000)e4"), c("(1.1", "0.1)e4"), c("(1.111", "0.001)e4"), c("(1.1111", "0.0001)e4"),
@@ -43,13 +50,23 @@ test_that("error formatting works properly", {
                  "11111.222(123)", "11111.2222(123)", "11111.2222200(123)", "11111.2222200000(123)"))
   options(saved_options)
 
+  x <- set_errors(rep(0.827, 3), c(0.119, 0.367, 0.962))
+  expect_equal(format(x, notation="plus-minus", digits="pdg"), sapply(list(
+    c("0.83", "0.12"), c("0.8", "0.4"), c("1", "1")),
+    paste, collapse=paste("", .pm, "")))
+
   x <- set_errors(10, 1)
   expect_equal(format(x - set_errors(10)), "0(1)")
   expect_equal(format(x - x), "0(0)")
 
-  x <- set_errors(c(0.4, NA, NaN, Inf))
+  x <- set_errors(c(0.4, NA, NaN, Inf, -Inf))
   expect_equal(format(x[1]), "0.4(0)")
   expect_equal(format(x[2]), "NA(NA)")
   expect_equal(format(x[3]), "NaN(NaN)")
   expect_equal(format(x[4]), "Inf(Inf)")
+  expect_equal(format(x[5]), "-Inf(Inf)")
+
+  x <- set_errors(c(0e10, 1e12), 0.1e12)
+  expect_equal(format(x), c("0.0(1)e12", "1.0(1)e12"))
+  expect_equal(format(x, digits=2), c("0.00(10)e12", "1.00(10)e12"))
 })


### PR DESCRIPTION
Slight rework of #60. Closes #47.